### PR TITLE
Authorization method header is now case-insensitive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ build-docker:
 	@docker build -t $(project) .
 
 run:
-	@reflex -c reflex.conf -- sh -c ./Will.IAM start-api
+	@reflex -c reflex.conf -- sh -c ./bin/Will.IAM start-api
 
 migrate:
 	@migrate -path migrations -database ${database} up

--- a/api/am_handlers_test.go
+++ b/api/am_handlers_test.go
@@ -26,7 +26,7 @@ func beforeEachAMHandlers(t *testing.T) {
 
 func TestAMListHandler(t *testing.T) {
 	beforeEachAMHandlers(t)
-	rootSA := helpers.CreateRootServiceAccount(t)
+	rootSA := helpers.CreateRootServiceAccountWithKeyPair(t)
 	// saUC := helpers.GetServiceAccountsUseCase(t)
 	app := helpers.GetApp(t)
 	type testCase struct {

--- a/api/auth_middleware.go
+++ b/api/auth_middleware.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/sirupsen/logrus"
 	"github.com/topfreegames/Will.IAM/errors"
 	"github.com/topfreegames/Will.IAM/usecases"
 	"github.com/topfreegames/extensions/middleware"
@@ -13,6 +14,14 @@ import (
 type serviceAccountIDCtxKeyType string
 
 const serviceAccountIDCtxKey = serviceAccountIDCtxKeyType("serviceAccountID")
+const keyPairHeader = "KeyPair"
+const bearerTokenHeader = "Bearer"
+
+type authorizationHeader struct {
+	Header  string
+	Type    string
+	Content string
+}
 
 func getServiceAccountID(ctx context.Context) (string, bool) {
 	v := ctx.Value(serviceAccountIDCtxKey)
@@ -24,57 +33,125 @@ func getServiceAccountID(ctx context.Context) (string, bool) {
 }
 
 // authMiddleware authenticates either access_token or key pair
-func authMiddleware(
-	sasUC usecases.ServiceAccounts,
-) func(http.Handler) http.Handler {
+func authMiddleware(sasUC usecases.ServiceAccounts) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			authorization := r.Header.Get("authorization")
-			parts := strings.Split(authorization, " ")
-			if authorization == "" || len(parts) != 2 {
-				w.WriteHeader(http.StatusUnauthorized)
+		return http.HandlerFunc(func(responseWriter http.ResponseWriter, request *http.Request) {
+			header := request.Header.Get("authorization")
+			authHeaderContents := strings.Split(header, " ")
+			authHeader := buildAuth(header, authHeaderContents[0], authHeaderContents[1])
+
+			if !authHeader.isValid() {
+				responseWriter.WriteHeader(http.StatusUnauthorized)
 				return
 			}
+
 			var ctx context.Context
-			l := middleware.GetLogger(r.Context())
-			if strings.EqualFold(parts[0], "KeyPair") {
-				keyPair := strings.Split(parts[1], ":")
-				accessKeyPairAuth, err := sasUC.WithContext(r.Context()).
-					AuthenticateKeyPair(keyPair[0], keyPair[1])
-				if err != nil {
-					l.WithError(err).Error("auth failed")
-					w.WriteHeader(http.StatusInternalServerError)
-					return
-				}
-				w.Header().Set("x-service-account-name", accessKeyPairAuth.Name)
-				ctx = context.WithValue(r.Context(), serviceAccountIDCtxKey, accessKeyPairAuth.ServiceAccountID)
-			} else if strings.EqualFold(parts[0], "Bearer") {
-				accessToken := parts[1]
-				accessTokenAuth, err := sasUC.WithContext(r.Context()).
-					AuthenticateAccessToken(accessToken)
-				if err != nil {
-					l.WithError(err).Info("auth failed")
-					if _, ok := err.(*errors.EntityNotFoundError); ok {
-						w.WriteHeader(http.StatusUnauthorized)
-						return
-					}
-					l.Error(err)
-					w.WriteHeader(http.StatusInternalServerError)
-					return
-				}
-				w.Header().Set("x-email", accessTokenAuth.Email)
-				if accessTokenAuth.AccessToken != accessToken {
-					w.Header().Set("x-access-token", accessTokenAuth.AccessToken)
-				}
-				ctx = context.WithValue(
-					r.Context(), serviceAccountIDCtxKey, accessTokenAuth.ServiceAccountID,
-				)
+			var err error
+			logger := middleware.GetLogger(request.Context())
+
+			if authHeader.isKeyPair() {
+				ctx, err = handleKeyPairAuthorization(request, responseWriter, authHeader, sasUC, logger)
+			} else if authHeader.isBearerToken() {
+				ctx, err = handleBearerTokenAuthorization(request, responseWriter, authHeader, sasUC, logger)
 			} else {
-				l.WithError(errors.NewInvalidAuthorizationTypeError()).Error("auth failed")
-				w.WriteHeader(http.StatusUnauthorized)
+				handleUndefinedAuthorizationType(responseWriter, logger)
 				return
 			}
-			next.ServeHTTP(w, r.WithContext(ctx))
+
+			if err != nil {
+				return
+			}
+
+			next.ServeHTTP(responseWriter, request.WithContext(ctx))
 		})
 	}
+}
+
+func buildAuth(header string, method string, content string) authorizationHeader {
+	return authorizationHeader{
+		Header:  header,
+		Type:    method,
+		Content: content,
+	}
+}
+
+func (auth authorizationHeader) isValid() bool {
+	if auth.Header == "" || auth.Type == "" || auth.Content == "" {
+		return false
+	}
+	return true
+}
+
+func (auth authorizationHeader) isKeyPair() bool {
+	return strings.EqualFold(auth.Type, keyPairHeader)
+}
+
+func (auth authorizationHeader) isBearerToken() bool {
+	return strings.EqualFold(auth.Type, bearerTokenHeader)
+}
+
+func handleKeyPairAuthorization(
+	request *http.Request,
+	responseWriter http.ResponseWriter,
+	authHeader authorizationHeader,
+	sasUC usecases.ServiceAccounts,
+	logger logrus.FieldLogger,
+) (context.Context, error) {
+
+	keyPair := strings.Split(authHeader.Content, ":")
+	accessKeyPairAuth, err := sasUC.WithContext(request.Context()).AuthenticateKeyPair(keyPair[0], keyPair[1])
+
+	if err != nil {
+		logger.WithError(err).Error("auth failed")
+		responseWriter.WriteHeader(http.StatusInternalServerError)
+		return nil, err
+	}
+
+	responseWriter.Header().Set("x-service-account-name", accessKeyPairAuth.Name)
+
+	ctx := context.WithValue(request.Context(), serviceAccountIDCtxKey, accessKeyPairAuth.ServiceAccountID)
+	return ctx, nil
+}
+
+func handleBearerTokenAuthorization(
+	request *http.Request,
+	responseWriter http.ResponseWriter,
+	authHeader authorizationHeader,
+	sasUC usecases.ServiceAccounts,
+	logger logrus.FieldLogger,
+) (context.Context, error) {
+
+	accessToken := authHeader.Content
+	accessTokenAuth, err := sasUC.WithContext(request.Context()).AuthenticateAccessToken(accessToken)
+
+	if err != nil {
+		logger.WithError(err).Info("auth failed")
+
+		if _, ok := err.(*errors.EntityNotFoundError); ok {
+			responseWriter.WriteHeader(http.StatusUnauthorized)
+			return nil, err
+		}
+
+		logger.Error(err)
+		responseWriter.WriteHeader(http.StatusInternalServerError)
+		return nil, err
+	}
+
+	responseWriter.Header().Set("x-email", accessTokenAuth.Email)
+
+	if accessTokenAuth.AccessToken != accessToken {
+		responseWriter.Header().Set("x-access-token", accessTokenAuth.AccessToken)
+	}
+
+	ctx := context.WithValue(request.Context(), serviceAccountIDCtxKey, accessTokenAuth.ServiceAccountID)
+	return ctx, nil
+}
+
+func handleUndefinedAuthorizationType(
+	responseWriter http.ResponseWriter,
+	logger logrus.FieldLogger,
+) {
+	logger.WithError(errors.NewInvalidAuthorizationTypeError()).Error("auth failed")
+	responseWriter.WriteHeader(http.StatusUnauthorized)
+	return
 }

--- a/api/auth_middleware.go
+++ b/api/auth_middleware.go
@@ -37,7 +37,7 @@ func authMiddleware(
 			}
 			var ctx context.Context
 			l := middleware.GetLogger(r.Context())
-			if parts[0] == "KeyPair" {
+			if strings.EqualFold(parts[0], "KeyPair") {
 				keyPair := strings.Split(parts[1], ":")
 				accessKeyPairAuth, err := sasUC.WithContext(r.Context()).
 					AuthenticateKeyPair(keyPair[0], keyPair[1])
@@ -48,7 +48,7 @@ func authMiddleware(
 				}
 				w.Header().Set("x-service-account-name", accessKeyPairAuth.Name)
 				ctx = context.WithValue(r.Context(), serviceAccountIDCtxKey, accessKeyPairAuth.ServiceAccountID)
-			} else if parts[0] == "Bearer" {
+			} else if strings.EqualFold(parts[0], "Bearer") {
 				accessToken := parts[1]
 				accessTokenAuth, err := sasUC.WithContext(r.Context()).
 					AuthenticateAccessToken(accessToken)

--- a/api/auth_middleware.go
+++ b/api/auth_middleware.go
@@ -49,11 +49,12 @@ func authMiddleware(sasUC usecases.ServiceAccounts) func(http.Handler) http.Hand
 			var err error
 			logger := middleware.GetLogger(r.Context())
 
-			if authHeader.isKeyPair() {
+			switch authHeader.Type {
+			case models.AuthenticationTypes.KeyPair:
 				ctx, err = handleKeyPairAuth(r, w, authHeader, sasUC)
-			} else if authHeader.isOAuth2() {
+			case models.AuthenticationTypes.OAuth2:
 				ctx, err = handleOAuth2TokenAuth(r, w, authHeader, sasUC)
-			} else {
+			default:
 				handleUndefinedAuthType(w, logger)
 				return
 			}
@@ -91,14 +92,6 @@ func (auth authorizationHeader) isValid() bool {
 		return false
 	}
 	return true
-}
-
-func (auth authorizationHeader) isKeyPair() bool {
-	return strings.EqualFold(auth.Type.String(), models.AuthenticationTypes.KeyPair.String())
-}
-
-func (auth authorizationHeader) isOAuth2() bool {
-	return strings.EqualFold(auth.Type.String(), models.AuthenticationTypes.OAuth2.String())
 }
 
 func handleKeyPairAuth(

--- a/api/auth_middleware.go
+++ b/api/auth_middleware.go
@@ -51,11 +51,11 @@ func authMiddleware(sasUC usecases.ServiceAccounts) func(http.Handler) http.Hand
 			logger := middleware.GetLogger(request.Context())
 
 			if authHeader.isKeyPair() {
-				ctx, err = handleKeyPairAuthorization(request, responseWriter, authHeader, sasUC, logger)
+				ctx, err = handleKeyPairAuth(request, responseWriter, authHeader, sasUC, logger)
 			} else if authHeader.isOAuth2() {
-				ctx, err = handleBearerTokenAuthorization(request, responseWriter, authHeader, sasUC, logger)
+				ctx, err = handleOAuth2TokenAuth(request, responseWriter, authHeader, sasUC, logger)
 			} else {
-				handleUndefinedAuthorizationType(responseWriter, logger)
+				handleUndefinedAuthType(responseWriter, logger)
 				return
 			}
 
@@ -101,7 +101,7 @@ func (auth authorizationHeader) isOAuth2() bool {
 	return strings.EqualFold(auth.Type.String(), models.AuthenticationTypes.OAuth2.String())
 }
 
-func handleKeyPairAuthorization(
+func handleKeyPairAuth(
 	request *http.Request,
 	responseWriter http.ResponseWriter,
 	authHeader authorizationHeader,
@@ -124,7 +124,7 @@ func handleKeyPairAuthorization(
 	return ctx, nil
 }
 
-func handleBearerTokenAuthorization(
+func handleOAuth2TokenAuth(
 	request *http.Request,
 	responseWriter http.ResponseWriter,
 	authHeader authorizationHeader,
@@ -158,7 +158,7 @@ func handleBearerTokenAuthorization(
 	return ctx, nil
 }
 
-func handleUndefinedAuthorizationType(
+func handleUndefinedAuthType(
 	responseWriter http.ResponseWriter,
 	logger logrus.FieldLogger,
 ) {

--- a/api/auth_middleware.go
+++ b/api/auth_middleware.go
@@ -76,7 +76,7 @@ func buildAuth(header, method, content string) authorizationHeader {
 	} else if strings.EqualFold(method, bearerTokenHeader) {
 		authType = models.AuthenticationTypes.OAuth2
 	} else {
-		authType = ""
+		authType = models.AuthenticationTypes.Unknown
 	}
 
 	return authorizationHeader{

--- a/api/auth_middleware_test.go
+++ b/api/auth_middleware_test.go
@@ -16,7 +16,7 @@ func TestAuthMiddlewareKeyPairShouldAuthenticateUser(t *testing.T) {
 	req, _ := http.NewRequest(http.MethodGet, "/service_accounts", nil)
 
 	req.Header.Set("Authorization", fmt.Sprintf(
-		"KeyPair %s:%s", rootSA.KeyID, rootSA.KeySecret,
+		"keypair %s:%s", rootSA.KeyID, rootSA.KeySecret,
 	))
 
 	response := helpers.DoRequest(t, req, app.GetRouter())
@@ -41,7 +41,7 @@ func TestAuthMiddlewareBearerShouldAuthenticateUser(t *testing.T) {
 	app := helpers.GetApp(t)
 	req, _ := http.NewRequest(http.MethodGet, "/service_accounts", nil)
 
-	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
+	req.Header.Set("Authorization", fmt.Sprintf("bearer %s", token))
 	response := helpers.DoRequest(t, req, app.GetRouter())
 
 	if response.Code != http.StatusOK {

--- a/api/auth_middleware_test.go
+++ b/api/auth_middleware_test.go
@@ -8,24 +8,48 @@ import (
 	helpers "github.com/topfreegames/Will.IAM/testing"
 )
 
-func TestAuthMiddlewareKeyPair(t *testing.T) {
+func TestAuthMiddlewareKeyPairShouldAuthenticateUser(t *testing.T) {
 	helpers.CleanupPG(t)
 
-	rootSA := helpers.CreateRootServiceAccount(t)
-
+	rootSA := helpers.CreateRootServiceAccountWithKeyPair(t)
 	app := helpers.GetApp(t)
-
 	req, _ := http.NewRequest(http.MethodGet, "/service_accounts", nil)
+
 	req.Header.Set("Authorization", fmt.Sprintf(
 		"KeyPair %s:%s", rootSA.KeyID, rootSA.KeySecret,
 	))
-	rec := helpers.DoRequest(t, req, app.GetRouter())
-	if rec.Code != http.StatusOK {
-		t.Errorf("Expected status %d. Got %d", http.StatusOK, rec.Code)
+
+	response := helpers.DoRequest(t, req, app.GetRouter())
+
+	if response.Code != http.StatusOK {
+		t.Errorf("Expected status %d. Got %d", http.StatusOK, response.Code)
 	}
 
-	serviceAccountName := rec.Header().Get("x-service-account-name")
+	serviceAccountName := response.Header().Get("x-service-account-name")
 	if serviceAccountName != "root" {
 		t.Errorf("Expected service account name %s. Got %s", "root", serviceAccountName)
+	}
+}
+
+func TestAuthMiddlewareBearerShouldAuthenticateUser(t *testing.T) {
+	helpers.CleanupPG(t)
+
+	rootSA := helpers.CreateRootServiceAccountWithOAuth(t)
+	tokensRepo := helpers.GetRepo(t).Tokens
+	tokens, _ := tokensRepo.FindByEmail(rootSA.Email)
+	token := tokens[0]
+	app := helpers.GetApp(t)
+	req, _ := http.NewRequest(http.MethodGet, "/service_accounts", nil)
+
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
+	response := helpers.DoRequest(t, req, app.GetRouter())
+
+	if response.Code != http.StatusOK {
+		t.Errorf("Expected status %d. Got %d", http.StatusOK, response.Code)
+	}
+
+	serviceAccountEmail := response.Header().Get("x-email")
+	if serviceAccountEmail != rootSA.Email {
+		t.Errorf("Expected service account email %s. Got %s", rootSA.Email, serviceAccountEmail)
 	}
 }

--- a/api/auth_middleware_test.go
+++ b/api/auth_middleware_test.go
@@ -13,7 +13,11 @@ func TestAuthMiddlewareKeyPairShouldAuthenticateUser(t *testing.T) {
 
 	rootSA := helpers.CreateRootServiceAccountWithKeyPair(t)
 	app := helpers.GetApp(t)
-	req, _ := http.NewRequest(http.MethodGet, "/service_accounts", nil)
+	req, err := http.NewRequest(http.MethodGet, "/service_accounts", nil)
+
+	if err != nil {
+		t.Errorf("Could not create HTTP request for /service_accounts")
+	}
 
 	req.Header.Set("Authorization", fmt.Sprintf(
 		"keypair %s:%s", rootSA.KeyID, rootSA.KeySecret,
@@ -39,7 +43,11 @@ func TestAuthMiddlewareBearerShouldAuthenticateUser(t *testing.T) {
 	tokens, _ := tokensRepo.FindByEmail(rootSA.Email)
 	token := tokens[0]
 	app := helpers.GetApp(t)
-	req, _ := http.NewRequest(http.MethodGet, "/service_accounts", nil)
+	req, err := http.NewRequest(http.MethodGet, "/service_accounts", nil)
+
+	if err != nil {
+		t.Errorf("Could not create HTTP request for /service_accounts")
+	}
 
 	req.Header.Set("Authorization", fmt.Sprintf("bearer %s", token))
 	response := helpers.DoRequest(t, req, app.GetRouter())

--- a/api/permissions_handlers_test.go
+++ b/api/permissions_handlers_test.go
@@ -26,7 +26,7 @@ func beforeEachPermissionsHandlers(t *testing.T) {
 
 func TestPermissionsDeleteHandlerNonExistentID(t *testing.T) {
 	beforeEachRolesHandlers(t)
-	rootSA := helpers.CreateRootServiceAccount(t)
+	rootSA := helpers.CreateRootServiceAccountWithKeyPair(t)
 	app := helpers.GetApp(t)
 	req, _ := http.NewRequest("DELETE", fmt.Sprintf(
 		"/permissions/%s", uuid.Must(uuid.NewV4()).String(),
@@ -43,7 +43,7 @@ func TestPermissionsDeleteHandlerNonExistentID(t *testing.T) {
 func TestPermissionsDeleteHandlerNonRootSA(t *testing.T) {
 	beforeEachRolesHandlers(t)
 	saUC := helpers.GetServiceAccountsUseCase(t)
-	rootSA := helpers.CreateRootServiceAccount(t)
+	rootSA := helpers.CreateRootServiceAccountWithKeyPair(t)
 	sa, err := saUC.CreateKeyPairType("some sa")
 	if err != nil {
 		t.Errorf("Unexpected error %s", err.Error())
@@ -86,7 +86,7 @@ func TestPermissionsDeleteHandlerNonRootSA(t *testing.T) {
 func TestPermissionsDeleteHandler(t *testing.T) {
 	beforeEachRolesHandlers(t)
 	saUC := helpers.GetServiceAccountsUseCase(t)
-	rootSA := helpers.CreateRootServiceAccount(t)
+	rootSA := helpers.CreateRootServiceAccountWithKeyPair(t)
 	sa, err := saUC.CreateKeyPairType("some sa")
 	if err != nil {
 		t.Errorf("Unexpected error %s", err.Error())

--- a/api/permissions_requests_handlers_test.go
+++ b/api/permissions_requests_handlers_test.go
@@ -34,7 +34,7 @@ func TestPermissionsRequestsListHandler(t *testing.T) {
 	if rec.Code != http.StatusCreated {
 		t.Fatalf("Expected status 201. Got %d", rec.Code)
 	}
-	rootSA := helpers.CreateRootServiceAccount(t)
+	rootSA := helpers.CreateRootServiceAccountWithKeyPair(t)
 	req, _ = http.NewRequest("GET", "/permissions/requests/open", nil)
 	req.Header.Set("Authorization", fmt.Sprintf(
 		"KeyPair %s:%s", rootSA.KeyID, rootSA.KeySecret,

--- a/api/roles_handlers_test.go
+++ b/api/roles_handlers_test.go
@@ -28,7 +28,7 @@ func beforeEachRolesHandlers(t *testing.T) {
 
 func TestRolesCreatePermissionHandler(t *testing.T) {
 	beforeEachRolesHandlers(t)
-	rootSA := helpers.CreateRootServiceAccount(t)
+	rootSA := helpers.CreateRootServiceAccountWithKeyPair(t)
 	saUC := helpers.GetServiceAccountsUseCase(t)
 	sa, err := saUC.CreateKeyPairType("some sa")
 	if err != nil {
@@ -94,7 +94,7 @@ func TestRolesCreatePermissionHandlerNonRootSA(t *testing.T) {
 func TestRolesUpdateHandlerRootSA(t *testing.T) {
 	beforeEachRolesHandlers(t)
 	saUC := helpers.GetServiceAccountsUseCase(t)
-	rootSA := helpers.CreateRootServiceAccount(t)
+	rootSA := helpers.CreateRootServiceAccountWithKeyPair(t)
 	targetSA, err := saUC.CreateKeyPairType("creator sa")
 	if err != nil {
 		t.Errorf("Unexpected error %s", err.Error())

--- a/api/service_accounts_handlers_test.go
+++ b/api/service_accounts_handlers_test.go
@@ -10,6 +10,8 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/topfreegames/Will.IAM/models"
+
 	helpers "github.com/topfreegames/Will.IAM/testing"
 )
 
@@ -184,8 +186,14 @@ func TestServiceAccountListWithPermissionHandler(t *testing.T) {
 		beforeEachServiceAccountsHandlers(t)
 		rootSA := helpers.CreateRootServiceAccountWithKeyPair(t)
 
-		for i, p := range tt.sasPs {
-			helpers.CreateServiceAccountWithPermissions(t, fmt.Sprintf("sa%d", i), fmt.Sprintf("sa%d@email.com", i), "OAuth", p)
+		for i, permission := range tt.sasPs {
+			helpers.CreateServiceAccountWithPermissions(
+				t,
+				fmt.Sprintf("sa%d", i),
+				fmt.Sprintf("sa%d@email.com", i),
+				models.AuthenticationTypes.OAuth2,
+				permission,
+			)
 		}
 
 		params := url.Values{}

--- a/api/service_accounts_handlers_test.go
+++ b/api/service_accounts_handlers_test.go
@@ -69,7 +69,7 @@ func TestServiceAccountCreateHandler(t *testing.T) {
 	app := helpers.GetApp(t)
 	for _, tt := range tt {
 		beforeEachServiceAccountsHandlers(t)
-		rootSA := helpers.CreateRootServiceAccount(t)
+		rootSA := helpers.CreateRootServiceAccountWithKeyPair(t)
 		bts, err := json.Marshal(tt.body)
 		if err != nil {
 			t.Errorf("Unexpected error %s", err.Error())
@@ -89,7 +89,7 @@ func TestServiceAccountCreateHandler(t *testing.T) {
 func TestServiceAccountListHandler(t *testing.T) {
 	beforeEachServiceAccountsHandlers(t)
 
-	rootSA := helpers.CreateRootServiceAccount(t)
+	rootSA := helpers.CreateRootServiceAccountWithKeyPair(t)
 
 	app := helpers.GetApp(t)
 
@@ -182,10 +182,10 @@ func TestServiceAccountListWithPermissionHandler(t *testing.T) {
 
 	for caseID, tt := range saListWithPermissionTestCases {
 		beforeEachServiceAccountsHandlers(t)
-		rootSA := helpers.CreateRootServiceAccount(t)
+		rootSA := helpers.CreateRootServiceAccountWithKeyPair(t)
 
 		for i, p := range tt.sasPs {
-			helpers.CreateServiceAccountWithPermissions(t, fmt.Sprintf("sa%d", i), p)
+			helpers.CreateServiceAccountWithPermissions(t, fmt.Sprintf("sa%d", i), fmt.Sprintf("sa%d@email.com", i), "OAuth", p)
 		}
 
 		params := url.Values{}

--- a/api/services_handlers_test.go
+++ b/api/services_handlers_test.go
@@ -24,7 +24,7 @@ func beforeEachServices(t *testing.T) {
 
 func TestServicesCreateHandler(t *testing.T) {
 	beforeEachServices(t)
-	rootSA := helpers.CreateRootServiceAccount(t)
+	rootSA := helpers.CreateRootServiceAccountWithKeyPair(t)
 	saUC := helpers.GetServiceAccountsUseCase(t)
 	sa := &models.ServiceAccount{
 		Name:  "any",

--- a/models/service_account.go
+++ b/models/service_account.go
@@ -27,9 +27,13 @@ var AuthenticationTypes = struct {
 	KeyPair: "keypair",
 }
 
+func (authType AuthenticationType) String() string {
+	return string(authType)
+}
+
 // Valid checks if at is a possible value
-func (at AuthenticationType) Valid() bool {
-	if string(at) == "oauth2" || string(at) == "keypair" {
+func (authType AuthenticationType) Valid() bool {
+	if authType.String() == AuthenticationTypes.OAuth2.String() || authType.String() == AuthenticationTypes.KeyPair.String() {
 		return true
 	}
 	return false

--- a/models/service_account.go
+++ b/models/service_account.go
@@ -22,9 +22,11 @@ type AuthenticationType string
 var AuthenticationTypes = struct {
 	OAuth2  AuthenticationType
 	KeyPair AuthenticationType
+	Unknown AuthenticationType
 }{
 	OAuth2:  "oauth2",
 	KeyPair: "keypair",
+	Unknown: "unknown",
 }
 
 func (authType AuthenticationType) String() string {

--- a/oauth2/provider.go
+++ b/oauth2/provider.go
@@ -39,7 +39,7 @@ func (p *ProviderBlankMock) ExchangeCode(any string) (*models.AuthResult, error)
 
 // Authenticate dummy
 func (p *ProviderBlankMock) Authenticate(any string) (*models.AuthResult, error) {
-	email := "any@email.com"
+	email := "root@test.com"
 	if p.Email != "" {
 		email = p.Email
 	}

--- a/reflex.conf
+++ b/reflex.conf
@@ -1,2 +1,2 @@
 # Rebuilds and restart server when a .go file is changed
- -r '^.*\.go$' -R '^docker_data/' -s -- sh -c 'make build && ./Will.IAM start-api'
+ -r '^.*\.go$' -R '^docker_data/' -s -- sh -c 'make build && ./bin/Will.IAM start-api'

--- a/repositories/tokens.go
+++ b/repositories/tokens.go
@@ -11,6 +11,7 @@ type Tokens interface {
 	Save(*models.Token) error
 	Clone() Tokens
 	setStorage(*Storage)
+	FindByEmail(string) ([]models.Token, error)
 }
 
 type tokens struct {
@@ -43,6 +44,16 @@ func (ts tokens) Save(token *models.Token) error {
 	?expiry, ?email, now()) ON CONFLICT (access_token) DO UPDATE SET
 	expired_at = ?expired_at, updated_at = now()`, token)
 	return err
+}
+
+func (ts tokens) FindByEmail(email string) ([]models.Token, error) {
+	tokens := []models.Token{}
+	if _, err := ts.storage.PG.DB.Query(
+		&tokens, `SELECT * FROM tokens WHERE email = ?`, email,
+	); err != nil {
+		return nil, err
+	}
+	return tokens, nil
 }
 
 // NewTokens ctor

--- a/usecases/permissions_requests_test.go
+++ b/usecases/permissions_requests_test.go
@@ -193,7 +193,7 @@ func TestPermissionsRequestsListVisibleTo(t *testing.T) {
 		t.Errorf("Unexpected error: %s", err.Error())
 		return
 	}
-	rootSA := helpers.CreateRootServiceAccount(t)
+	rootSA := helpers.CreateRootServiceAccountWithKeyPair(t)
 	prs, count, err := prsUC.ListOpenRequestsVisibleTo(&repositories.ListOptions{}, rootSA.ID)
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err.Error())
@@ -421,7 +421,7 @@ func TestPermissionsRequestsGrant(t *testing.T) {
 		t.Errorf("Expected saM to NOT have permission")
 		return
 	}
-	rootSA := helpers.CreateRootServiceAccount(t)
+	rootSA := helpers.CreateRootServiceAccountWithKeyPair(t)
 	if err := prsUC.Grant(rootSA.ID, pr.ID); err != nil {
 		t.Errorf("Unexpected error: %s", err.Error())
 		return
@@ -502,7 +502,7 @@ func TestPermissionsRequestsDeny(t *testing.T) {
 		t.Errorf("Unexpected error: %s", err.Error())
 		return
 	}
-	rootSA := helpers.CreateRootServiceAccount(t)
+	rootSA := helpers.CreateRootServiceAccountWithKeyPair(t)
 	if err := prsUC.Deny(rootSA.ID, pr.ID); err != nil {
 		t.Errorf("Unexpected error: %s", err.Error())
 		return
@@ -584,7 +584,7 @@ func TestPermissionsRequestsGrantWhenPRIsNotOpen(t *testing.T) {
 		t.Errorf("Unexpected error: %s", err.Error())
 		return
 	}
-	rootSA := helpers.CreateRootServiceAccount(t)
+	rootSA := helpers.CreateRootServiceAccountWithKeyPair(t)
 	if err := prsUC.Deny(rootSA.ID, pr.ID); err != nil {
 		t.Errorf("Unexpected error: %s", err.Error())
 		return
@@ -628,7 +628,7 @@ func TestPermissionsRequestsDenyWhenPRIsNotOpen(t *testing.T) {
 		t.Errorf("Unexpected error: %s", err.Error())
 		return
 	}
-	rootSA := helpers.CreateRootServiceAccount(t)
+	rootSA := helpers.CreateRootServiceAccountWithKeyPair(t)
 	if err := prsUC.Deny(rootSA.ID, pr.ID); err != nil {
 		t.Errorf("Unexpected error: %s", err.Error())
 		return

--- a/usecases/service_accounts_test.go
+++ b/usecases/service_accounts_test.go
@@ -254,7 +254,7 @@ func TestServiceAccountsListWithPermissionWhenPermissionOnBaseRole(t *testing.T)
 	for i, tt := range saListWithPermissionTestCases {
 		helpers.CleanupPG(t)
 		saUC := helpers.GetServiceAccountsUseCase(t)
-		root := helpers.CreateRootServiceAccount(t)
+		root := helpers.CreateRootServiceAccountWithKeyPair(t)
 		sas := []*usecases.ServiceAccountWithNested{}
 		for j, psStr := range tt.sasPs {
 			ps, err := models.BuildPermissions(psStr)
@@ -305,7 +305,7 @@ func TestServiceAccountsListWithPermissionWhenPermissionOnNonBaseRole(t *testing
 	for i, tt := range saListWithPermissionTestCases {
 		helpers.CleanupPG(t)
 		saUC := helpers.GetServiceAccountsUseCase(t)
-		root := helpers.CreateRootServiceAccount(t)
+		root := helpers.CreateRootServiceAccountWithKeyPair(t)
 		sas := []*models.ServiceAccount{}
 		for j, psStr := range tt.sasPs {
 			sa := &models.ServiceAccount{


### PR DESCRIPTION
# Motivation and Context

Will.IAM accepts two forms of authorisation:

* OAuth2 Bearer token
* KeyPair key_id and key_secret

That comes in the Headers as `Authorization Bearer {TOKEN}` and `Authorization KeyPair {key_id:key_secret}`, respectively.

Until now, the Header's authorisation method part - `Bearer` or `KeyPair` - was case-sensitive, which could cause some confusion as Will.IAM would return an Unauthorised response when that part was misspelled, e.g. `bearer` or `keypair`. This PR fixes that, while still keeping the behaviour of the actual token and key-pair parts.

# What was done

The fix for the case-sensitive situation was rather simple: instead of directly comparing the strings with an equality operator `==`, now we are using the method `strings.EqualFold ` from the [standard library](https://golang.org/pkg/strings/#EqualFold), which does not consider the string casing in the comparison.

## Extra

You may have noted that there are more things happening in this PR than the fix described above ☝️

* I refactored the `api.authMiddleware` function by performing some method extractions on its internal logic. Now, the logic for OAuth2, KeyPair and Undefined authorisation methods are handled by different functions. IMO, this makes the code easier to read and change. (Want to hear your thoughts about that 😄 )

* Another refactor was to ✂️ [magic strings](https://deviq.com/magic-strings/) and use the types defined in `AuthenticationTypes`. This will make the code DRYer by keeping the types definitions into a single place.

* I added a test for the OAuth2 authorisation flow, which required the creation of a few helper functions and a way to access OAuth2 tokens from the database.

* I fixed the Makefile target `run` and `reflex.conf` to point to the correct binary - the one generated by the `build` target, which is placed inside the `bin/` folder after the compilation.
Previously, it was looking for a binary in the root folder - probably generated by running the command `go build` there.
