### PR TITLE
Endpoint /permissions/has responds with correct HTTP status

### DIFF
--- a/api/permissions_handlers.go
+++ b/api/permissions_handlers.go
@@ -171,7 +171,8 @@ func permissionsHasHandler(
 			sasUC.WithContext(r.Context()).HasPermissionString(saID, permissionSl[0])
 		if err != nil {
 			l.Error(err)
-			w.WriteHeader(http.StatusInternalServerError)
+			Write(w, http.StatusUnprocessableEntity,
+				`{"error": "Incomplete permission. Expected format: Service::OwnershipLevel::Action::{ResourceHierarchy}"}`)
 			return
 		}
 		if !has {

--- a/api/permissions_handlers_test.go
+++ b/api/permissions_handlers_test.go
@@ -129,41 +129,41 @@ func TestPermissionsDeleteHandler(t *testing.T) {
 func TestPermissionsHasHandler(t *testing.T) {
 	beforeEachPermissionsHandlers(t)
 	type hasPermissionTest struct {
-		testName        string
-		request         string
-		expectedStatus  int
-		expectedMessage string
+		name        string
+		request     string
+		wantStatus  int
+		wantMessage string
 	}
 	testCases := []hasPermissionTest{
 		hasPermissionTest{
-			testName:        "MissingQueryString",
-			request:         "/permissions/has",
-			expectedStatus:  http.StatusUnprocessableEntity,
-			expectedMessage: `{"error": "querystrings.permission is required"}`,
+			name:        "MissingQueryString",
+			request:     "/permissions/has",
+			wantStatus:  http.StatusUnprocessableEntity,
+			wantMessage: `{"error": "querystrings.permission is required"}`,
 		},
 		hasPermissionTest{
-			testName:        "MissingPermissionQueryStringContent",
-			request:         "/permissions/has?permission=",
-			expectedStatus:  http.StatusUnprocessableEntity,
-			expectedMessage: `{"error": "Incomplete permission. Expected format: Service::OwnershipLevel::Action::{ResourceHierarchy}"}`,
+			name:        "MissingPermissionQueryStringContent",
+			request:     "/permissions/has?permission=",
+			wantStatus:  http.StatusUnprocessableEntity,
+			wantMessage: `{"error": "Incomplete permission. Expected format: Service::OwnershipLevel::Action::{ResourceHierarchy}"}`,
 		},
 		hasPermissionTest{
-			testName:        "WrongFormatPermissionQueryString",
-			request:         "/permissions/has?permission=X",
-			expectedStatus:  http.StatusUnprocessableEntity,
-			expectedMessage: `{"error": "Incomplete permission. Expected format: Service::OwnershipLevel::Action::{ResourceHierarchy}"}`,
+			name:        "WrongFormatPermissionQueryString",
+			request:     "/permissions/has?permission=X",
+			wantStatus:  http.StatusUnprocessableEntity,
+			wantMessage: `{"error": "Incomplete permission. Expected format: Service::OwnershipLevel::Action::{ResourceHierarchy}"}`,
 		},
 		hasPermissionTest{
-			testName:        "NotAuthorizedPermission",
-			request:         "/permissions/has?permission=Service::RL::TestAction::*",
-			expectedStatus:  http.StatusForbidden,
-			expectedMessage: "",
+			name:        "NotAuthorizedPermission",
+			request:     "/permissions/has?permission=Service::RL::TestAction::*",
+			wantStatus:  http.StatusForbidden,
+			wantMessage: "",
 		},
 		hasPermissionTest{
-			testName:        "AuthorizedPermission",
-			request:         "/permissions/has?permission=Service::RL::TestAction2::*",
-			expectedStatus:  http.StatusOK,
-			expectedMessage: "",
+			name:        "AuthorizedPermission",
+			request:     "/permissions/has?permission=Service::RL::TestAction2::*",
+			wantStatus:  http.StatusOK,
+			wantMessage: "",
 		},
 	}
 
@@ -171,7 +171,7 @@ func TestPermissionsHasHandler(t *testing.T) {
 	app := helpers.GetApp(t)
 
 	for _, testCase := range testCases {
-		t.Run(testCase.testName, func(t *testing.T) {
+		t.Run(testCase.name, func(t *testing.T) {
 			req, _ := http.NewRequest("GET", testCase.request, nil)
 			req.Header.Set("Authorization", fmt.Sprintf(
 				"KeyPair %s:%s", sa.KeyID, sa.KeySecret,
@@ -179,12 +179,12 @@ func TestPermissionsHasHandler(t *testing.T) {
 
 			rec := helpers.DoRequest(t, req, app.GetRouter())
 
-			if rec.Code != testCase.expectedStatus {
-				t.Errorf("Expected HTTP status %d. Got %d", testCase.expectedStatus, rec.Code)
+			if rec.Code != testCase.wantStatus {
+				t.Errorf("Expected HTTP status %d. Got %d", testCase.wantStatus, rec.Code)
 			}
 
-			if rec.Body.String() != testCase.expectedMessage {
-				t.Errorf("Expected response body %s. Got %s", testCase.expectedMessage, rec.Body)
+			if rec.Body.String() != testCase.wantMessage {
+				t.Errorf("Expected response body %s. Got %s", testCase.wantMessage, rec.Body)
 			}
 		})
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Changes the HTTP response code of the endpoint `GET /permissions/has` from 500 to 422 - Unprocessable Entity when receiving incorrect input. Also added a few more tests to cover more scenarios.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The endpoint `/permissions/has` is used to check if the current user has access to a given resource. It expects the query-string `?permission=<PERMISSION>` to indicate what permission we are checking against.

Prior to this PR, the endpoint responded with status HTTP 500 when it received a wrong input from clients, e.g.

* missing the query-string -> `GET /permissions/has`
* query-string without content - `GET /permissions/has?permission=`
* permission in wrong format -> `GET /permission/has?permission=XYZ`

Given that these errors are expected and belong to the client, returning an HTTP 4XX response would be the correct status here. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

- [X] Tests in the API
- [ ] Tests with Hub integration

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Release Strategy

The endpoint statuses changed, so we need to check if no clients will be affected before this goes live.