### PR TITLE
Fix webhook URL

### DIFF
--- a/push_to_docker.sh
+++ b/push_to_docker.sh
@@ -27,7 +27,7 @@ main() {
   docker push "$DOCKER_HUB_REPO:$last_commit_sha"
   docker push "$DOCKER_HUB_REPO:$TRAVIS_TAG"
 
-  curl -X POST "$TEST_FARM_URL&VERSION=$TRAVIS_TAG"
+  curl -X POST "$TEST_FARM_URL?&VERSION=$TRAVIS_TAG"
 }
 
 main "$@"


### PR DESCRIPTION
Fixes the webhook URL in `push_to_docker.sh`. It was missing the character `?` before the query-strings definitions.