### PR TITLE
Add feature flag for checking hosted domain

### DIFF
--- a/api/app.go
+++ b/api/app.go
@@ -110,10 +110,11 @@ func (a *App) configureJaeger() error {
 func (a *App) configureGoogleOAuth2Provider() {
 	repo := repositories.New(a.storage)
 	google := oauth2.NewGoogle(oauth2.GoogleConfig{
-		ClientID:      a.config.GetString("oauth2.google.clientId"),
-		ClientSecret:  a.config.GetString("oauth2.google.clientSecret"),
-		RedirectURL:   a.config.GetString("oauth2.google.redirectUrl"),
-		HostedDomains: a.config.GetStringSlice("oauth2.google.hostedDomains"),
+		ClientID:          a.config.GetString("oauth2.google.clientId"),
+		ClientSecret:      a.config.GetString("oauth2.google.clientSecret"),
+		RedirectURL:       a.config.GetString("oauth2.google.redirectUrl"),
+		CheckHostedDomain: a.config.GetBool("oauth2.google.checkHostedDomain"),
+		HostedDomains:     a.config.GetStringSlice("oauth2.google.hostedDomains"),
 	}, repo)
 	a.oauth2Provider = google
 }

--- a/config/local.yaml
+++ b/config/local.yaml
@@ -8,6 +8,7 @@ oauth2:
     clientId: dummy
     clientSecret: dummy
     redirectUrl: dummy
+    checkHostedDomain: true
     hostedDomains:
       - domain1
       - domain2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,3 +11,5 @@ services:
       - "postgres"
       - "-c"
       - "max_connections=9999"
+    environment:
+      - POSTGRES_HOST_AUTH_METHOD=trust

--- a/oauth2/google.go
+++ b/oauth2/google.go
@@ -22,10 +22,11 @@ const userEndpoint = "https://www.googleapis.com/oauth2/v2/userinfo"
 // GoogleConfig are the basic required informations to use Google
 // as oauth2 provider
 type GoogleConfig struct {
-	ClientID      string
-	ClientSecret  string
-	RedirectURL   string
-	HostedDomains []string
+	ClientID          string
+	ClientSecret      string
+	RedirectURL       string
+	CheckHostedDomain bool
+	HostedDomains     []string
 }
 
 var googleConfig GoogleConfig
@@ -196,7 +197,7 @@ func (g *Google) getUserInfo(accessToken string) (*userInfo, error) {
 }
 
 func (g *Google) checkHostedDomain(hd string) bool {
-	if g.config.HostedDomains == nil || len(g.config.HostedDomains) == 0 {
+	if !g.config.CheckHostedDomain || g.config.HostedDomains == nil || len(g.config.HostedDomains) == 0 {
 		return true
 	}
 	for _, allowed := range g.config.HostedDomains {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add a feature flag to toggle hosted domain check.

## Motivation and Context
I have a deployment of Will.IAM where I tried to override the config `oauth2.google.hostedDomains` through the env. var passing the empty string so I could receive an empty string slice from Viper (empty list of hosted domains), but Viper or Golang thinks the env. var. is not set, instead of understanding it is set to the empty string, and fallbacks to the default config (`{domain1, domain2}` in the default config file `config/local.yaml`).

## How Has This Been Tested?

Manually in my machine.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has tests.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Release strategy
<!-- What steps are needed in order to successfully deploy this PR. -->
<!-- For instance, this PR needs a dependency that must be in place in advance? -->
